### PR TITLE
Better handling types, specifically list of types

### DIFF
--- a/src/AvoSchemaParser.ts
+++ b/src/AvoSchemaParser.ts
@@ -71,7 +71,8 @@ export class AvoSchemaParser {
     });
   }
 
-  private static getPropValueType(propValue: any): string {
+
+  private static getBasicPropType(propValue: any): string {
     let propType = typeof propValue;
     if (propValue == null) {
       return "null";
@@ -86,13 +87,29 @@ export class AvoSchemaParser {
     } else if (propType === "boolean") {
       return "boolean";
     } else if (propType === "object") {
-      if (isArray(propValue)) {
-        return "list";
-      } else {
-        return "object";
+      return "object"
+  }
+  else {
+  return "unknown";
+  }
+}
+
+  private static getPropValueType(propValue: any): string {
+    if (isArray(propValue)){
+
+      //we now know that propValue is an array. get first element in propValue array
+      let propElement = propValue[0];
+
+      if (propElement == null) {
+        return "list(string)"; // Default to list(string) if the list is empty.
       }
-    } else {
-      return "unknown";
+      else {
+      let propElementType = this.getBasicPropType(propElement);
+      return `list(${propElementType})`
+      }
+    }
+    else {
+      return this.getBasicPropType(propValue);
     }
   }
 }

--- a/src/__tests__/TestParsing.ts
+++ b/src/__tests__/TestParsing.ts
@@ -60,7 +60,7 @@ describe("Schema Parsing", () => {
       },
     ]);
 
-    expect(res[7].propertyType).toBe(type.LIST);
+    expect(res[7].propertyType).toBe(type.STRINGLIST);
     expect(res[7].children).toMatchObject([
       type.STRING,
       [
@@ -88,13 +88,7 @@ describe("Schema Parsing", () => {
     const res = inspector.extractSchema(eventProperties);
 
     // Then
-    expect(res[0].propertyType).toBe(type.LIST);
-    expect(res[0].children).toMatchObject([
-      type.STRING,
-      type.BOOL,
-      type.INT,
-      type.FLOAT,
-    ]);
+    expect(res[0].propertyType).toBe(type.STRINGLIST);
   });
 
   test("Empty and falsy values are set correctly", () => {
@@ -124,7 +118,36 @@ describe("Schema Parsing", () => {
     expect(res[6].propertyType).toBe(type.OBJECT);
     expect(res[6].children).toMatchObject([]);
 
-    expect(res[7].propertyType).toBe(type.LIST);
+    expect(res[7].propertyType).toBe(type.STRINGLIST);
     expect(res[7].children).toMatchObject([]);
   });
+
+  test("List of string returns list(string)", () => {
+    // Given
+    const eventProperties = {
+      prop0: ["a", "b", "c"],
+    };
+
+    // When
+    const res = inspector.extractSchema(eventProperties);
+
+    // Then
+    expect(res[0].propertyType).toBe(type.STRINGLIST);
+  });
+
+
+  test("List of multiple types returns list(`firstType`)", () => {
+    // Given
+    const eventProperties = {
+      prop0: [1.2, "two", {"three": 3}],
+    };
+
+    // When
+    const res = inspector.extractSchema(eventProperties);
+
+    // Then
+    expect(res[0].propertyType).toBe(type.FLOATLIST);
+  });
+
+
 });

--- a/src/__tests__/constants.ts
+++ b/src/__tests__/constants.ts
@@ -37,13 +37,18 @@ const sessionTimeMs = 5 * 60 * 1000;
 
 const type = {
   STRING: "string",
+  STRINGLIST: "list(string)",
   INT: "int",
+  INTLIST: "list(int)",
   OBJECT: "object",
+  OBJECTLIST: "list(object)",
   FLOAT: "float",
-  LIST: "list",
+  FLOATLIST: "list(float)",
   BOOL: "boolean",
+  BOOLLIST: "list(boolean)",
   NULL: "null",
   UNKNOWN: "unknown",
+  UNKNOWNLIST: "list(unknown)",
 };
 
 export {


### PR DESCRIPTION
I noticed in our backend, that we were getting a lot of types that were "list", which I had no idea what to convert to.

This PR is to attempt to better understand the types coming in from the client and assign it as "list(string)" list(`type`).
I modified the tests accordingly and added few new ones to validate the new logic.

If this change gets accepted, it has to be replicated in the other JS libraries along with generated code for CDP's.

Assigning this to alex to review after vacation