### PR TITLE
Wait for both inspector calls to resolve in trackSchemaInternal

### DIFF
--- a/src/AvoInspector.ts
+++ b/src/AvoInspector.ts
@@ -182,7 +182,7 @@ export class AvoInspector {
     }
   }
 
-  private trackSchemaInternal(
+  private async trackSchemaInternal(
     eventName: string,
     eventSchema: Array<{
       propertyName: string;
@@ -194,33 +194,27 @@ export class AvoInspector {
   ): Promise<void> {
     try {
       const seesionId = AvoGuid.newGuid();
-      return this.avoNetworkCallsHandler
+      await this.avoNetworkCallsHandler
         .callInspectorWithBatchBody([
           this.avoNetworkCallsHandler.bodyForSessionStartedCall(seesionId),
-        ])
-        .then(() => {
-          if (AvoInspector.shouldLog) {
-            console.log("Avo Inspector: session started sent successfully.");
-          }
-          this.avoNetworkCallsHandler.callInspectorWithBatchBody([
-            this.avoNetworkCallsHandler.bodyForEventSchemaCall(
-              seesionId,
-              eventName,
-              eventSchema,
-              eventId,
-              eventHash
-            ),
-          ]).then(() => {
-            if (AvoInspector.shouldLog) {
-              console.log("Avo Inspector: schema sent successfully.");
-            }
-          });
-        })
-        .catch((err) => {
-          if (AvoInspector.shouldLog) {
-            console.log("Avo Inspector: schema sending failed: " + err + ".");
-          }
-        });
+        ]);
+
+      if (AvoInspector.shouldLog) {
+        console.log("Avo Inspector: session started sent successfully.");
+      }
+      await this.avoNetworkCallsHandler.callInspectorWithBatchBody([
+        this.avoNetworkCallsHandler.bodyForEventSchemaCall(
+          seesionId,
+          eventName,
+          eventSchema,
+          eventId,
+          eventHash
+        ),
+      ]).catch((err) => {
+        if (AvoInspector.shouldLog) {
+          console.log("Avo Inspector: schema sending failed: " + err + ".");
+        }
+      });
     } catch (e) {
       console.error(
         "Avo Inspector: something went wrong. Please report to support@avo.app.",

--- a/src/__tests__/TestDeduplicator.ts
+++ b/src/__tests__/TestDeduplicator.ts
@@ -3,6 +3,10 @@ import { deepEquals } from "../utils";
 import { AvoInspector } from "../AvoInspector";
 import { defaultOptions } from "./constants";
 
+jest
+  .useFakeTimers()
+  .setSystemTime(new Date('2020-01-01'));
+
 describe("Deduplicator", () => {
   const deduplicator = new AvoDeduplicator();
 


### PR DESCRIPTION
There is an issue with the implementation of `trackSchemaInternal`, where the promise returned by this function resolves before the second inspector call finishes. This can lead to unexpected behaviour - for example, trying to use `trackSchemaFromEvent` in an AWS lambda function results in the Lambda function finishing too early, causing errors.

This PR fixes this issue and adds a new unit test to prevent future regressions.

The file with the deduplicator tests has also been updated to make use of the fake timers. The reason for this is that there is time-sensitive logic in the deduplicator, which can cause intermittent test failures if tests are running longer than expected. Using fake timers removes the dependency on the running time of tests.