### PR TITLE
fix: restore id-token:write for claude-code-action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,6 +38,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary
- Restores `id-token: write` permission that was removed in PR #35
- The `anthropics/claude-code-action` requires OIDC token exchange even when using OAuth tokens

## Test plan
- [x] Merge this, then comment `@claude review` on PR #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow permissions to support additional authentication capabilities.

---

*Note: This release contains no user-visible changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->